### PR TITLE
add console reporter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,14 +26,14 @@ module.exports = function (grunt) {
 				options: {
 					runType: 'runner',
 					config: 'tests-intern/intern.local',
-					reporters: ['runner']
+					reporters: ['runner', 'console']
 				}
 			},
 			remote: {
 				options: {
 					runType: 'runner',
 					config: 'tests-intern/intern',
-					reporters: ['runner']
+					reporters: ['runner', 'console']
 				}
 			},
 			proxy: {
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
 					runType: 'runner',
 					proxyOnly: true,
 					config: 'tests-intern/intern.proxy',
-					reporters: ['runner']
+					reporters: ['runner', 'console']
 				}
 			}
 		}


### PR DESCRIPTION
Can we add console as a default reporter too? I like seeing the output of tests after a browser has closed
Maybe it'd be a better option to update grunt instead?  i.e. something like http://gruntjs.com/api/grunt.option  
