### PR TITLE
Changed tests to pass in IE8.

### DIFF
--- a/tests-intern/unit/promise/all.js
+++ b/tests-intern/unit/promise/all.js
@@ -47,13 +47,13 @@ define([
 
 		'without arguments': function () {
 			all().then(this.async().callback(function (result) {
-				assert.isUndefined(result);
+				assert.isTrue(typeof result === 'undefined');
 			}));
 		},
 
 		'with single non-object argument': function () {
 			all(null).then(this.async().callback(function (result) {
-				assert.isUndefined(result);
+				assert.isTrue(typeof result === 'undefined');
 			}));
 		},
 

--- a/tests-intern/unit/promise/first.js
+++ b/tests-intern/unit/promise/first.js
@@ -41,26 +41,26 @@ define([
 		'without arguments': function () {
 			first().then(this.async().callback(function () {
 				assert.equal(arguments.length, 1);
-				assert.typeOf(arguments[0], 'undefined');
+				assert.isTrue(typeof arguments[0] === 'undefined');
 			}));
 		},
 
 		'with single non-object argument': function () {
 			first(null).then(this.async().callback(function () {
 				assert.equal(arguments.length, 1);
-				assert.typeOf(arguments[0], 'undefined');
+				assert.isTrue(typeof arguments[0] === 'undefined');
 			}));
 		},
 
 		'with empty array': function () {
 			first([]).then(this.async().callback(function (received) {
-				assert.typeOf(received, 'undefined');
+				assert.isTrue(typeof received === 'undefined');
 			}));
 		},
 
 		'with empty object': function () {
 			first({}).then(this.async().callback(function (received) {
-				assert.typeOf(received, 'undefined');
+				assert.isTrue(typeof received === 'undefined');
 			}));
 		},
 


### PR DESCRIPTION
`assert.isUndefined` has a tough time in IE8.  Every test that I tried using `isUndefined` would return a strange error of `undefinedundefined` and I am not exactly sure why.

`assert.typeOf` also does not work exactly as intended either.  `assert.typeOf` seems to have no trouble working in modern Chrome and IE8.
